### PR TITLE
Update 02-etcd-backup-cronjob.yaml

### DIFF
--- a/openshift/02-etcd-backup-cronjob.yaml
+++ b/openshift/02-etcd-backup-cronjob.yaml
@@ -15,6 +15,7 @@ spec:
       backoffLimit: 2
       template:
         spec:
+          hostNetwork: true
           serviceAccountName: etcd-backup
           restartPolicy: Never
           dnsPolicy: ClusterFirst


### PR DESCRIPTION
Allow host network for container, to avoid errors like: "localhost:6443 - is unavailable"